### PR TITLE
Add softMocksErrors option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ npm install @testplane/mocks --save-dev
    - `(test: Test) => string`: (ex: `path.join(path.dirname(test.file), "testplane-dumps")`. `testplane-dumps` directories will be located next to each Testplane test). Saves tests' dumps to directories by path, returned by the function
 * **dumpsKey** (optional) `(requestUrl: string) => string` - function to create dumps key from request url. Сan be used to remove query parameters that unique every time. If you dont remove unique query params, you will encounter an error `Cache is empty: key=...` on `play` mode.
 * **gzipDumps** (optional) `Boolean` - enable/disable dump compressing. By default dumps are written and read in compressed form
+* **softMocksErrors** (optional) `Boolean` - soft handling of mocks errors (e.g. `Cache is empty: key=...`). Default - `false`. By default a mocks error fails an otherwise-passing test and replaces the error of a failing one. When set to `true`:
+   - a passing test is **not** failed because of a mocks error;
+   - a failing test keeps its real error as the top-level one, and the mocks error is attached as the **deepest `cause`**, so it stays visible without hiding the real failure reason.
 
 Also there is ability to override plugin parameters by CLI options or environment variables (see [configparser](https://github.com/gemini-testing/configparser)).
 

--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -14,6 +14,7 @@ describe("config", () => {
             mode: RunMode.Play,
             dumpsDir: DUMPS_DIR,
             gzipDumps: true,
+            softMocksErrors: false,
         });
     });
 
@@ -133,6 +134,18 @@ describe("config", () => {
         it("should parse option", () => {
             expect(parseConfig({ gzipDumps: true })).toMatchObject({
                 gzipDumps: true,
+            });
+        });
+    });
+
+    describe("softMocksErrors", () => {
+        it("should throw if it is not type of Boolean", () => {
+            expect(() => parseConfig({ softMocksErrors: "asd" })).toThrow(/must be a boolean/);
+        });
+
+        it("should parse option", () => {
+            expect(parseConfig({ softMocksErrors: true })).toMatchObject({
+                softMocksErrors: true,
             });
         });
     });

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -21,6 +21,7 @@ export type PluginConfig = {
     dumpsDir: string | ((test: Test) => string);
     dumpsKey: (requestUrl: string) => string;
     gzipDumps: boolean;
+    softMocksErrors: boolean;
 };
 
 export function parseConfig(options: PluginConfig): PluginConfig {
@@ -34,6 +35,7 @@ export function parseConfig(options: PluginConfig): PluginConfig {
             dumpsDir: dumpsDirOption("dumpsDir", DUMPS_DIR),
             dumpsKey: dumpsKeyOption("dumpsKey", _.identity),
             gzipDumps: booleanOption("gzipDumps", true),
+            softMocksErrors: booleanOption("softMocksErrors", false),
         }),
         {
             envPrefix: "testplane_mocks_",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { TARGET_PAGE, TEST_MOCKS_ERROR } from "./constants";
 import { createWorkersRunner } from "./workers";
 import { Store } from "./store";
 import { parseConfig } from "./config";
+import { attachErrorAsDeepestCause } from "./utils";
 import { useModes, readMode, writeMode } from "./modes";
 import type { PluginConfig } from "./config";
 import type { WorkersRunner } from "./workers/worker";
@@ -110,14 +111,27 @@ export = (testplane: Testplane, opts: PluginConfig): void => {
     });
 
     testplane.intercept(testplane.events.TEST_PASS, ({ data }) => {
-        return _.get(data, TEST_MOCKS_ERROR) && { event: testplane.events.TEST_FAIL, data };
+        // In soft mode a mocks error must not turn a passing test into a failing one.
+        const shouldFail = Boolean(_.get(data, TEST_MOCKS_ERROR)) && !config.softMocksErrors;
+
+        return shouldFail ? { event: testplane.events.TEST_FAIL, data } : undefined;
     });
 
     testplane.intercept(testplane.events.TEST_FAIL, ({ data }) => {
-        if (_.get(data, TEST_MOCKS_ERROR)) {
-            const test = data as Test;
+        const mocksError = _.get(data, TEST_MOCKS_ERROR) as Error | undefined;
 
-            test.err = _.get(data, TEST_MOCKS_ERROR);
+        if (!mocksError) {
+            return;
+        }
+
+        const test = data as Test;
+
+        // In soft mode keep the real failure as the top-level error and hang the mocks
+        // error at the deepest cause; otherwise preserve the legacy behavior and overwrite.
+        if (config.softMocksErrors && test.err) {
+            attachErrorAsDeepestCause(test.err as Error, mocksError);
+        } else {
+            test.err = mocksError;
         }
     });
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,56 @@
+import { attachErrorAsDeepestCause } from "./utils";
+
+type WithCause = Error & { cause?: unknown };
+
+describe("attachErrorAsDeepestCause", () => {
+    it("should attach cause to an error without an existing cause", () => {
+        const root = new Error("root");
+        const cause = new Error("cause");
+
+        attachErrorAsDeepestCause(root, cause);
+
+        expect((root as WithCause).cause).toBe(cause);
+    });
+
+    it("should attach cause to the deepest error in the chain", () => {
+        const leaf = new Error("leaf");
+        const mid = new Error("mid") as WithCause;
+        mid.cause = leaf;
+        const root = new Error("root") as WithCause;
+        root.cause = mid;
+        const cause = new Error("mocks");
+
+        attachErrorAsDeepestCause(root, cause);
+
+        expect((leaf as WithCause).cause).toBe(cause);
+        expect(root.cause).toBe(mid);
+    });
+
+    it("should not attach cause if it is already present in the chain", () => {
+        const cause = new Error("mocks");
+        const root = new Error("root") as WithCause;
+        root.cause = cause;
+
+        attachErrorAsDeepestCause(root, cause);
+
+        expect(root.cause).toBe(cause);
+        expect((cause as WithCause).cause).toBeUndefined();
+    });
+
+    it("should not attach cause deeper than the max depth", () => {
+        const root = new Error("root") as WithCause;
+        let deepest: WithCause = root;
+
+        for (let i = 0; i < 25; i++) {
+            const next = new Error(`level-${i}`) as WithCause;
+            deepest.cause = next;
+            deepest = next;
+        }
+
+        const cause = new Error("mocks");
+
+        attachErrorAsDeepestCause(root, cause);
+
+        expect((deepest as WithCause).cause).toBeUndefined();
+    });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,30 @@
+type WithCause = Error & { cause?: unknown };
+
+// Guards the cause-chain traversal against cyclic or excessively long chains.
+const MAX_CAUSE_DEPTH = 20;
+
+/**
+ * Hangs `causeError` at the very bottom of `rootError`'s `cause` chain.
+ *
+ * Used by the soft handling of mocks errors: a real test failure stays the top-level
+ * error, while the mocks error (e.g. "Cache is empty") remains visible as the deepest
+ * cause instead of replacing the real one.
+ */
+export function attachErrorAsDeepestCause(rootError: Error, causeError: Error): void {
+    let current: WithCause = rootError;
+
+    for (let depth = 0; depth < MAX_CAUSE_DEPTH; depth++) {
+        // Already somewhere in the chain — don't attach twice (protects against cycles).
+        if (current === causeError) {
+            return;
+        }
+
+        if (!current.cause || typeof current.cause !== "object") {
+            current.cause = causeError;
+
+            return;
+        }
+
+        current = current.cause as WithCause;
+    }
+}


### PR DESCRIPTION
Current behaviour: when encountering a missing request, test always fails.
This behaviour is kept as-is with softMocksErrors: false (default).

With softMocksErrors enabled: 
- If there are missing requests, but those are not relevant for this test (test passes) - there is no error now, test passes.
- If there are missing requests and test failed - they will be attached as a cause to the failure rather than replacing a failure.

Co-authored by Claude (sorry), reviewed and tested by human.